### PR TITLE
ItemStateChangeTrigger has previousState property and moved ChannelEventTrigger up

### DIFF
--- a/lib/openhab/triggers.py
+++ b/lib/openhab/triggers.py
@@ -26,11 +26,13 @@ class ItemStateUpdateTrigger(Trigger):
         Trigger.__init__(self, triggerName, "core.ItemStateUpdateTrigger", Configuration(config))
 
 class ItemStateChangeTrigger(Trigger):
-    def __init__(self, itemName, state=None, triggerName=None):
+    def __init__(self, itemName, state=None, triggerName=None, previousState=None):):
         triggerName = triggerName or uuid.uuid1().hex
         config = { "itemName": itemName }
         if state is not None:
             config["state"] = state
+        if previousState is not None:
+            config["previousState"] = previousState
         Trigger.__init__(self, triggerName, "core.ItemStateChangeTrigger", Configuration(config))
 
 class ItemCommandTrigger(Trigger):
@@ -40,6 +42,15 @@ class ItemCommandTrigger(Trigger):
         if command is not None:
             config["command"] = command
         Trigger.__init__(self, triggerName, "core.ItemCommandTrigger", Configuration(config))
+
+class ChannelEventTrigger(Trigger):
+    def __init__(self, channelUID, event, triggerName=None):
+        triggerName = triggerName or uuid.uuid1().hex
+        #self.log.debug("Trigger: " + triggerName + "; channel: " + channelUID)
+        config = { "channelUID": channelUID }
+        config["event"] = event
+        Trigger.__init__(self, triggerName, "core.ChannelEventTrigger", Configuration(config))
+        self.setLabel(triggerName)
 
 EVERY_SECOND = "0/1 * * * * ?"
 EVERY_MINUTE = "0 * * * * ?"
@@ -177,12 +188,3 @@ def item_group_triggered(group_name, event_types=None, result_item_name=None, tr
         get_automation_manager().addRule(rule)
         return fn
     return decorator
-
-class ChannelEventTrigger(Trigger):
-    def __init__(self, channelUID, event, triggerName=None):
-        triggerName = triggerName or uuid.uuid1().hex
-        #self.log.debug("Trigger: " + triggerName + "; channel: " + channelUID)
-        config = { "channelUID": channelUID }
-        config["event"] = event
-        Trigger.__init__(self, triggerName, "core.ChannelEventTrigger", Configuration(config))
-        self.setLabel(triggerName)


### PR DESCRIPTION
i needed the previousState property to the ItemStateChangeTrigger.

for example:

```
lass rule_automate_ventilation_new(SimpleRule):
    def __init__(self):
        self.triggers = [ 
                            StartupTrigger(),                                                               # Run on startup to initialize, will reset the timer(!)
                            ItemCommandTrigger("timer_rule_automate_ventilation_new_init_hardware", command="OFF"),                       # GUI instellingen      
                            ItemCommandTrigger("number_ventilator_level_set_manual"),                       # GUI instellingen      
                            ItemStateChangeTrigger("switch_ventilator_level_toggle_auto",state="ON", previousState="OFF"),      # Manual mode gaat uit na 20 minuten
                            ItemStateChangeTrigger("humid_status_badkamer_sensor")                          # luchtvochtigheid verandert in badkamer
                        ]
    def execute(self, module, input):
```

I've also moved the ChannelEventTrigger up, so it's positioned with the other triggers.
