### PR TITLE
Module with class that simulates executeCommandLine with a timeout

### DIFF
--- a/lib/openhab/command.py
+++ b/lib/openhab/command.py
@@ -1,0 +1,21 @@
+# This modue simulates executeCommandLine with a timeout. It will return a tuple (stdoutdata, stdouterr).
+import subprocess, threading
+
+class Command(object):
+    def __init__(self, cmd):
+        self.cmd = cmd
+        self.process = None
+        self.data = None
+
+    def run(self, timeout):
+        def target():
+            self.process = subprocess.Popen(self.cmd,stdout=subprocess.PIPE)
+            self.data = self.process.communicate()
+
+        thread = threading.Thread(target=target)
+        thread.start()
+        thread.join(timeout)
+        if thread.is_alive():
+            self.process.terminate()
+            thread.join()
+        return self.data


### PR DESCRIPTION
I'm note sure if it is best to add this as a separate module, but it didn't seem to fit into an existing one. I'm also not sure if this is a good name for it. Usage is...
```
from openhab.command import Command
rawMessage = Command(['/usr/bin/curl','-s','-X','GET','https://api.wunderground.com/api/<WU_API_key>/alerts/hourly/conditions/q/pws:KOHBRUNS25.json']).run(timeout=10)[0]
```
Comparable to this in the Rules DSL...
```
    val String rawMessage = executeCommandLine("/bin/sh@@-c@@/usr/bin/curl -s -X GET https://api.wunderground.com/api/<WU_API_key>/alerts/hourly/conditions/q/pws:KOHBRUNS25.json",10000)
```