### PR TITLE
Combine item_group_triggered and item_triggered into the same decorator

### DIFF
--- a/lib/openhab/triggers.py
+++ b/lib/openhab/triggers.py
@@ -140,11 +140,12 @@ def time_triggered(cron_expression, trigger_name=None):
     return decorator
 
 ITEM_CHANGE = "ItemStateChangedEvent"
+GROUP_CHANGE = "GroupItemStateChangedEvent"
 ITEM_UPDATE = "ItemStateEvent"
 ITEM_COMMAND = "ItemCommandEvent"
 
-def item_triggered(item_name, event_types=None, result_item_name=None, trigger_name=None):
-    event_types = event_types or [ITEM_CHANGE]
+def item_triggered(item_name, groupAsItem=False, allMembers=True, event_types=None, result_item_name=None, trigger_name=None):
+    event_types = event_types or ([ITEM_CHANGE] if allMembers else [GROUP_CHANGE])
     event_bus = scope.events
     if hasattr(event_types, '__iter__'):
         event_types = ",".join(event_types)
@@ -158,33 +159,14 @@ def item_triggered(item_name, event_types=None, result_item_name=None, trigger_n
             result_value = fn(*fn_args)
             if result_item_name:
                 event_bus.postUpdate(result_item_name, unicode(result_value))
-        rule = _FunctionRule(callback, [ItemEventTrigger(item_name, event_types)], 
-                             extended=True, name=trigger_name)
-        get_automation_manager().addRule(rule)
-        return fn
-    return decorator
-
-
-def item_group_triggered(group_name, event_types=None, result_item_name=None, trigger_name=None):
-    event_types = event_types or [ITEM_CHANGE]
-    event_bus = scope.events
-    if hasattr(event_types, '__iter__'):
-        event_types = ",".join(event_types)
-    def decorator(fn):
-        nargs = len(inspect.getargspec(fn).args)
-        def callback(module, inputs):
-            fn_args = []
-            event = inputs.get('event')
-            if event and nargs == 1:
-                fn_args.append(event)
-            result_value = fn(*fn_args)
-            if result_item_name:
-                event_bus.postUpdate(result_item_name, unicode(result_value))
-        group_triggers = []
-        group = scope.itemRegistry.getItem(group_name)
-        for i in group.getAllMembers():
-            group_triggers.append(ItemEventTrigger(i.name, event_types))
-        rule = _FunctionRule(callback, group_triggers, extended=True, name=trigger_name)
+        item = scope.itemRegistry.getItem(item_name)
+        triggers = []
+        if not groupAsItem and item.type == "Group":
+            for i in (item.getAllMembers() if allMembers else item.getMembers()):
+                triggers.append(ItemEventTrigger(i.name, event_types))
+        else:
+            triggers.append(ItemEventTrigger(item_name, event_types))
+        rule = _FunctionRule(callback, triggers, extended=True, name=trigger_name)
         get_automation_manager().addRule(rule)
         return fn
     return decorator


### PR DESCRIPTION
This change combines the two decorators, and adds the allMembers and groupAsItem arguments so that this single decorator...

1. Accepts a single item as the item_name (non-group item default)
2. Accepts a group item, using .getAllMembers (with allMembers=True)
3. Accepts a group item, using .getMembers (with allMembers=False)
4. Accepts a group item as an item (groupAsItem=True)

It made sense to me to combine all of this into one, rather than split them out into multiple decorators. Without any arguments other than item_name, item_triggered will create a single item trigger for items or individual item triggers for all members of a group. Use groupAsItem=True to create a rule that triggers on the state of a group changing. Use allMembers=False to create a rule with triggers for only a groups direct children (similar to 'Member of' in the Rules DSL).

