### PR TITLE
Reworked items.add() to use builder style item creation

### DIFF
--- a/automation/lib/python/openhab/items.py
+++ b/automation/lib/python/openhab/items.py
@@ -1,19 +1,37 @@
 # NOTE: Requires JythonItemProvider component
 
+from org.slf4j import Logger, LoggerFactory
+
 from openhab import osgi, jsr223, JythonItemProvider
-from org.eclipse.smarthome.core.library.items import StringItem
-from org.eclipse.smarthome.core.items import Item, ItemProvider
+from openhab.jsr223 import scope
 
 __all__ = ["add", "remove"]
 
-item_factory = osgi.get_service("org.eclipse.smarthome.core.items.ItemFactory")
 
-def add(item, item_type=None):
-    if isinstance(item, str):
-        if item_type is None:
-            raise Exception("Must provide item_type when creating an item by name")
-        item = item_factory.createItem(item_type, item)
-    JythonItemProvider.add(item)
+logger = LoggerFactory.getLogger("org.eclipse.smarthome.model.script.Rules.jsr232.openhab")
+
+def add(item, item_type=None, category=None, groups=None, label=None, gi_base_type=None, group_function=None):
+    try:
+        if isinstance(item, str):
+            if item_type is None:
+                raise Exception("Must provide item_type when creating an item by name")
+
+            baseItem = None if item_type != "Group" or gi_base_type is None else scope.itemRegistry.newItemBuilder( gi_base_type       \
+                                                                                                                  , item + "_baseItem")\
+                                                                                                   .build()
+            group_function = None if item_type != "Group" else group_function
+            item = scope.itemRegistry.newItemBuilder(item_type, item)  \
+                                     .withCategory(category)           \
+                                     .withGroups(groups)               \
+                                     .withLabel(label)                 \
+                                     .withBaseItem(baseItem)           \
+                                     .withGroupFunction(group_function)\
+                                     .build()
+
+        JythonItemProvider.add(item)
+    except:
+        import traceback
+        logger.error(traceback.format_exc())
 
 def remove(item):
     JythonItemProvider.remove(item)

--- a/automation/lib/python/openhab/items.py
+++ b/automation/lib/python/openhab/items.py
@@ -35,4 +35,3 @@ def add(item, item_type=None, category=None, groups=None, label=None, gi_base_ty
 
 def remove(item):
     JythonItemProvider.remove(item)
-

--- a/automation/lib/python/openhab/items.py
+++ b/automation/lib/python/openhab/items.py
@@ -12,7 +12,7 @@ logger = LoggerFactory.getLogger("org.eclipse.smarthome.model.script.Rules.jsr23
 
 def add(item, item_type=None, category=None, groups=None, label=None, gi_base_type=None, group_function=None):
     try:
-        if isinstance(item, str):
+        if isinstance(item, basestring):
             if item_type is None:
                 raise Exception("Must provide item_type when creating an item by name")
 
@@ -27,11 +27,13 @@ def add(item, item_type=None, category=None, groups=None, label=None, gi_base_ty
                                      .withBaseItem(baseItem)           \
                                      .withGroupFunction(group_function)\
                                      .build()
-
         JythonItemProvider.add(item)
     except:
         import traceback
         logger.error(traceback.format_exc())
+        return None
+    else:
+        return item
 
 def remove(item):
     JythonItemProvider.remove(item)


### PR DESCRIPTION
I reworked lib/python/openhab/items.py to use a more generalized method for creating new objects, in particular the reworked items.add() method allows for creation of GroupItems with full support for group base item types and group functions.