### PR TITLE
Corrected cron issue with simple rule trigger

### DIFF
--- a/automation/lib/python/openhab/triggers.py
+++ b/automation/lib/python/openhab/triggers.py
@@ -225,8 +225,8 @@ def when(target, target_type=None, trigger_type=None, old_state=None, new_state=
         trigger_target = None
         if isValidExpression(target):
             target_type = "Time"
-            trigger_type = "cron"
-            trigger_target = target
+            trigger_target = "cron"
+            trigger_type = target
         else:
             trigger_name = trigger_name or (target.replace(":","_").replace("#","_").replace(" ","-"))
             inputList = target.split(" ")
@@ -297,10 +297,10 @@ def when(target, target_type=None, trigger_type=None, old_state=None, new_state=
             else:# a simple Item target was used, so add default target_type and trigger_type (Item XXXXX changed)
                 if target_type is None:
                     target_type = "Item"
-                if trigger_type is None:
-                    trigger_type = "changed"
                 if trigger_target is None:
                     trigger_target = target
+                if trigger_type is None:
+                    trigger_type = "changed"
 
         # validate the inputs, and if anything isn't populated correctly throw an exception
         if target_type is None or target_type not in ["Item", "Member of", "Descendent of", "Thing", "Channel", "System", "Time"]:


### PR DESCRIPTION
There are two undocumented ways to quickly created triggers using the when decorator. This is just a short form similar to what was used with the old item_triggered decorator, and I carried it over into the when decorator.  The cron one broke after the recent refactor of the trigger validation in the when decorator, but this PR makes it work again.

Cron:
```
@rule("Cron: simple trigger")
@when("0 0 7 * * ?")
def testSimpleCron(event):
```

And 'Item `<item>` changed':
```
@rule("Item: simple trigger")
@when("Test_Switch_1")
def testSimpleItem(event):
```