### PR TITLE
Dockerfile

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,23 @@
+## From which base container as in https://hub.docker.com/r/openhab/openhab/#image-variants eg. 2.4.0.M6-armhf-debian
+ARG OPENHAB_VERSION
+FROM openhab/openhab:${OPENHAB_VERSION}
+
+## Where will we install jython inside container
+ARG JYTHON_HOME="/opt/jython"
+ARG JYTHON_VERSION="2.7.0"
+
+## To avoid the need to setup jython's opts by the user, we will modify EXTRA_JAVA_OPTS in init scripts ENV provided for convinience if you need to run it by hand
+ENV \
+  JYTHON_HOME="${JYTHON_HOME}" \
+  JYTHON_JAVA_OPTS="-Xbootclasspath/a:${JYTHON_HOME}/jython.jar -Dpython.home=${JYTHON_HOME} -Dpython.path=${JYTHON_HOME}/Lib:${APPDIR}/conf/automation/lib/python"
+
+## Install to /opt but allow writing $class files by giving every one permission to write, openhab user is created only after container has started
+RUN \
+  mkdir -p ${JYTHON_HOME} && \
+  wget http://central.maven.org/maven2/org/python/jython-installer/${JYTHON_VERSION}/jython-installer-${JYTHON_VERSION}.jar -O /tmp/jython-installer.jar && \
+  java -jar /tmp/jython-installer.jar -s -d ${JYTHON_HOME}/ -t standard -e demo doc src && \
+  rm /tmp/jython-installer.jar && \
+  chmod -R o+w ${JYTHON_HOME} 
+
+## Init scripts run on each container startup
+ADD cont-init.d/* /etc/cont-init.d/

--- a/Docker/cont-init.d/00-jython_initialize.sh
+++ b/Docker/cont-init.d/00-jython_initialize.sh
@@ -1,0 +1,20 @@
+## Export Jython's required Java options
+export EXTRA_JAVA_OPTS="${EXTRA_JAVA_OPTS} ${JYTHON_JAVA_OPTS}"
+
+## Clears jython's compiled classes in automation dir in case container has changed
+find ${APPDIR}/conf/automation/lib/python -name '*\$py.class' -delete
+
+## Ensure we are running new rule engine addon - is there a better way?
+MISC_LINE=$(grep '^[[:space:]]\?misc' ${APPDIR}/conf/services/addons.cfg)
+if [ $? -eq 0 ]; then
+  ## ensure we have ruleengine enabled
+  if [[ ${MISC_LINE} == *"ruleengine"* ]]; then
+    echo "New rule engine already scheduled to installation"
+  else 
+    sed -i 's/misc\s\?=\s\?/misc = ruleengine,/' ${APPDIR}/conf/services/addons.cfg
+  fi
+else
+  ## Just append last line
+  echo "misc = ruleengine" >> ${APPDIR}/conf/services/addons.cfg
+fi
+  

--- a/Docs/Docker.md
+++ b/Docs/Docker.md
@@ -54,3 +54,13 @@ Then, after a minute or two, this should appear in the logs every 10 seconds or 
 ```
 2018-10-17 02:24:40.077 [INFO ] [eclipse.smarthome.model.script.Rules] - JSR223: This is a 'hello world!' from a Jython rule (decorator): Cron
 ```
+
+## Building image from Dockerfile
+In root directory of project there is an example Dockerfile which will add Jython support to given container version. It includes a script to enable experimental rule engine in addons.cfg and adds necessary entries to `EXTRA_JAVA_OPTS` (including `/openhab/conf/automation/lib/python` in python.path). As a user, you only need to add python's scripts and rules to your `conf/automation/jsr223` volume.
+
+To build a container with jython, simply run:
+```
+docker build --build-arg OPENHAB_VERSION=2.4.0.M6-amd64-debian .
+```
+
+Jython will be installed in `/opt/jython`, installation directory as well as jython version, can be set with build args (see Dockerfile).


### PR DESCRIPTION
I'm very thankful for your work, these scripts are both good examples how to convert rules to Python, as well as make life easier. Since getting jython to run takes quite a lot of steps, I've decided to create a Dockerfile which will install Jython with all needed environment variables onto official Docker image of Openhab. 

Image was tested on debian version of amd64 and armhf flavours with M4, M5 and M6 images. It requires recent addition to official images which is a directory with scripts run on each startup. On each startup, it will enable experimental rule engine addon in addons.cfg and append python options to EXTRA_JAVA_OPTS.

openhab2-jython is not installed via dockerfile because, probably everybody will want to have their version in container's volumes for easier editing. One can easily write docker-compose on top of this Dockerfile.
