### PR TITLE
Refactor items.py and provider, and add links.py and provider, and small fix to log.py

### DIFF
--- a/Core/automation/jsr223/core/components/200_JythonItemChannelLinkProvider.py
+++ b/Core/automation/jsr223/core/components/200_JythonItemChannelLinkProvider.py
@@ -1,0 +1,45 @@
+from org.eclipse.smarthome.core.thing.link import ItemChannelLinkProvider
+
+import core
+import core.osgi
+
+class JythonItemChannelLinkProvider(ItemChannelLinkProvider):
+    def __init__(self):
+        self.listeners = []
+        self.links = []
+
+    def add(self, link):
+        self.links.append(link)
+        for listener in self.listeners:
+            listener.added(self, link)
+
+    def remove(self, link):
+        if link in self.links:
+            self.links.remove(link)
+            for listener in self.listeners:
+                listener.removed(self, link)
+
+    def getAll(self):
+        return self.links
+
+    def update(self, link):
+        for listener in self.listeners:
+            listener.updated(self, link)
+
+    def addProviderChangeListener(self, listener):
+        self.listeners.append(listener)
+
+    def removeProviderChangeListener(self, listener):
+        if listener in self.listeners:
+            self.listeners.remove(listener)
+
+core.JythonItemChannelLinkProvider = JythonItemChannelLinkProvider()
+
+def scriptLoaded(id):
+    core.osgi.register_service(
+        core.JythonItemChannelLinkProvider, 
+        ["org.eclipse.smarthome.core.thing.link.ItemChannelLinkProvider"])
+    
+def scriptUnloaded():
+    core.osgi.unregister_service(core.JythonItemChannelLinkProvider)
+    delattr(core, 'JythonItemChannelLinkProvider')

--- a/Core/automation/jsr223/core/components/200_JythonItemProvider.py
+++ b/Core/automation/jsr223/core/components/200_JythonItemProvider.py
@@ -7,22 +7,23 @@ class JythonItemProvider(ItemProvider):
     def __init__(self):
         self.listeners = []
         self.items = []
-        
+
     def add(self, item):
         self.items.append(item)
         for listener in self.listeners:
             listener.added(self, item)
-        
+
     def remove(self, item):
         if isinstance(item, str):
             for i in self.items:
                 if i.name == item:
                     self.remove(i)
         else:
-            self.items.remove(item)
-            for listener in self.listeners:
-                listener.removed(self, item)
-        
+            if item in self.items:
+                self.items.remove(item)
+                for listener in self.listeners:
+                    listener.removed(self, item)
+
     def getAll(self):
         return self.items
 
@@ -31,9 +32,10 @@ class JythonItemProvider(ItemProvider):
 
     def removeProviderChangeListener(self, listener):
         self.listeners.remove(listener)
-        
+
+core.JythonItemProvider = JythonItemProvider()
+
 def scriptLoaded(id):
-    core.JythonItemProvider = JythonItemProvider()
     core.osgi.register_service(
         core.JythonItemProvider, 
         ["org.eclipse.smarthome.core.items.ItemProvider"])

--- a/Core/automation/lib/python/core/items.py
+++ b/Core/automation/lib/python/core/items.py
@@ -1,14 +1,14 @@
 # NOTE: Requires JythonItemProvider component
-
 from core import osgi, jsr223, JythonItemProvider
 from core.jsr223 import scope
 from core.log import logging, LOG_PREFIX
+from core.links import remove_all_links
 
 log = logging.getLogger(LOG_PREFIX + ".core.items")
 
-__all__ = ["add", "remove"]
+__all__ = ["add_item", "remove_item"]
 
-def add(item, item_type=None, category=None, groups=None, label=None, tags=None, gi_base_type=None, group_function=None):
+def add_item(item, item_type=None, category=None, groups=None, label=None, tags=None, gi_base_type=None, group_function=None):
     try:
         if isinstance(item, basestring):
             if item_type is None:
@@ -21,11 +21,13 @@ def add(item, item_type=None, category=None, groups=None, label=None, tags=None,
                                     .withCategory(category)             \
                                     .withGroups(groups)                 \
                                     .withLabel(label)                   \
-                                    .withTags(tags)                     \
                                     .withBaseItem(baseItem)             \
                                     .withGroupFunction(group_function)  \
+                                    .withTags(set(tags))                \
                                     .build()
+
         JythonItemProvider.add(item)
+        log.debug("Item added: [{}]".format(item))
     except:
         import traceback
         log.error(traceback.format_exc())
@@ -33,5 +35,15 @@ def add(item, item_type=None, category=None, groups=None, label=None, tags=None,
     else:
         return item
 
-def remove(item):
-    JythonItemProvider.remove(item)
+def remove_item(item):
+    try:
+        if isinstance(item, basestring) and scope.itemRegistry.getItems(item):
+            item = scope.ir.getItem(item)
+        elif not (hasattr(item, 'name') and scope.itemRegistry.getItems(item.name)):
+            raise Exception("The 'item' argument must be a string or an existing Item")
+        remove_all_links(item)
+        JythonItemProvider.remove(item)
+        log.debug("Item removed: [{}]".format(item))
+    except:
+        import traceback
+        log.error(traceback.format_exc())

--- a/Core/automation/lib/python/core/links.py
+++ b/Core/automation/lib/python/core/links.py
@@ -1,0 +1,64 @@
+# NOTE: Requires JythonItemChannelLinkProvider component
+from core import osgi, jsr223, JythonItemChannelLinkProvider
+from core.jsr223 import scope
+from core.log import logging, LOG_PREFIX
+
+log = logging.getLogger(LOG_PREFIX + ".core.links")
+
+__all__ = ["add_link", "remove_link"]
+
+def validate_item(item):
+    if hasattr(item, 'name') and scope.itemRegistry.getItems(item.name):
+        item = item.name
+    elif not (isinstance(item, basestring) and scope.itemRegistry.getItems(item)):
+        raise Exception("The 'item' argument must be a string or an existing Item")
+    return item
+
+def validate_channel_uid(channel_uid):
+    from org.eclipse.smarthome.core.thing import ChannelUID
+    if isinstance(channel_uid, basestring) and scope.things.getChannel(ChannelUID(channel_uid)) is not None:
+        channel_uid = ChannelUID(channel_uid)
+    elif not (isinstance(channel_uid, ChannelUID) and scope.things.getChannel(channel_uid) is not None):
+        raise Exception("The 'channel_uid' argument must be a string or an existing ChannelUID")
+    return channel_uid
+
+def add_link(item, channel_uid):
+    try:
+        item = validate_item(item)
+        channel_uid = validate_channel_uid(channel_uid)
+        from org.eclipse.smarthome.core.thing.link import ItemChannelLink
+        link = ItemChannelLink(item, channel_uid)
+        JythonItemChannelLinkProvider.add(link)
+        log.debug("Link added: [{}]".format(link))
+    except:
+        import traceback
+        log.error(traceback.format_exc())
+        return None
+    else:
+        return link
+
+def remove_link(item, channel_uid):
+    try:
+        item = validate_item(item)
+        channel_uid = validate_channel_uid(channel_uid)
+        from org.eclipse.smarthome.core.thing.link import ItemChannelLink
+        link = ItemChannelLink(item, channel_uid)
+        JythonItemChannelLinkProvider.remove(link)
+        log.debug("Link removed: [{}]".format(link))
+    except:
+        import traceback
+        log.error(traceback.format_exc())
+
+def remove_all_links(item):
+    try:
+        item = validate_item(item)
+        ItemChannelLinkRegistry = osgi.get_service("org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry")
+        channels = ItemChannelLinkRegistry.getBoundChannels(item)
+        from org.eclipse.smarthome.core.thing.link import ItemChannelLink
+        links = map(lambda channel: ItemChannelLink(item, channel), channels)
+        for link in links:
+            JythonItemChannelLinkProvider.remove(link)
+            log.debug("Link removed: [{}]".format(link))
+    except:
+        import traceback
+        log.error(traceback.format_exc())

--- a/Core/automation/lib/python/core/log.py
+++ b/Core/automation/lib/python/core/log.py
@@ -55,7 +55,7 @@ def log_traceback(fn):
             if hasattr(core.actions, 'NotificationAction'):
                 import configuration
                 if hasattr(configuration, 'adminEmail') and configuration.adminEmail != "admin_email@some_domain.com":
-                    core.actions.NotificationAction.sendNotification(configuration.adminEmail, "Exception: {}:".format(rule_name, traceback.format_exc()))
+                    core.actions.NotificationAction.sendNotification(configuration.adminEmail, "Exception: {}: [{}]".format(rule_name, traceback.format_exc()))
                 else:
-                    core.actions.NotificationAction.sendBroadcastNotification("Exception: {}:".format(rule_name, traceback.format_exc()))
+                    core.actions.NotificationAction.sendBroadcastNotification("Exception: {}: [{}]".format(rule_name, traceback.format_exc()))
     return wrapper

--- a/Docs/Component-Scripts.md
+++ b/Docs/Component-Scripts.md
@@ -31,7 +31,7 @@ This rule trigger responds to events on the OSGI EventAdmin event bus.
 #### Script: [`100_StartupTrigger.py`](../Core/automation/jsr223/core/components/100_StartupTrigger.py)
 <ul>
 
-Defines a rule trigger that triggers immediately when a rule is activated. [not functional after an API change]
+Defines a rule trigger that triggers immediately when a rule is activated. [not functional yet]
 </ul>
 
 #### Script: [`100_ShutdownTrigger.py`](../Core/automation/jsr223/core/components/100_ShutdownTrigger.py)
@@ -54,13 +54,28 @@ This script defines a transformation service (identified by "JYTHON") that will 
 This is similar to the Javascript transformer.
 </ul>
 
-#### Scripts: Jython-based Providers
+#### Script [`200_JythonItemProvider.py`](../Core/automation/jsr223/core/components/200_JythonItemProvider.py)
 <ul>
 
-These components are used to support Thing handler implementations:
+This script adds an ItemProvider, so that Items can be added and removed at runtime.
+</ul>
+
+#### Script [`200_JythonItemChannelLinkProvider.py`](../Core/automation/jsr223/core/components/200_JythonItemChannelLinkProvider.py)
+<ul>
+
+This script adds an ItemChannelLinkProvider, so that Links can be added and removed at runtime.
+</ul>
+
+#### Script [`200_JythonBindingInfoProvider.py`](../Core/automation/jsr223/core/components/200_JythonBindingInfoProvider.py)
+<ul>
+
+This script adds a BindingInfoProvider.
+</ul>
+
+#### Scripts: Jython-based Thing Providers
+<ul>
+
+These components are used to support Thing Handler implementations:
 * [`200_JythonThingProvider.py`](../Core/automation/jsr223/core/components/200_JythonThingProvider.py)
 * [`200_JythonThingTypeProvider.py`](../Core/automation/jsr223/core/components/200_JythonThingTypeProvider.py)
-* [`200_JythonBindingInfoProvider.py`](../Core/automation/jsr223/core/components/200_JythonBindingInfoProvider.py)
-* [`200_JythonItemProvider.py`](../Core/automation/jsr223/core/components/200_JythonItemProvider.py)
-
 </ul>

--- a/Docs/Jython-Modules.md
+++ b/Docs/Jython-Modules.md
@@ -165,14 +165,34 @@ log.info("Logging example from logger, using text appended to LOG_PREFIX")
 <ul>
 
 This module allows runtime creation and removal of items.
+It will also remove any links from an Item before it is removed.
+Requires the JythonItemProvder and JythonItemChannelLinkProvider component scripts.
 
 ```python
 import core.items
 
-core.items.add("_Test", "String")
+core.items.add_item("Test_String", item_type="String", label="Test String")
 
 # later...
-core.items.remove("_Test")
+core.items.remove_item("Test_String")
+
+```
+</ul>
+
+#### Module: [`core.links`](../Core/automation/lib/python/core/links.py)
+<ul>
+
+This module allows runtime creation and removal of links.
+Requires the JythonItemChannelLinkProvider component script.
+Take a look at the [Community OWM script](../Community/OpenWeatherMap/automation/jsr223/community/openweathermap/owm_daily_forecast.py) for an example usage.
+
+```python
+import core.links
+
+core.links.add_link("Kodi_Control", channel_uid="kodi:kodi:familyroom:control")
+
+# later...
+core.link.remove_link("Kodi_Control")
 
 ```
 </ul>


### PR DESCRIPTION
This will introduce a breaking change for items.py. There is some namespace conflict with the default scope, but I think we can work around that. But the ItemChannelLinkProvider is needed for removing Items, since the links need to be removed before the Item can be removed. When I also added links.py, it was getting messing having core.items.add and core.links.add, so I renamed them to core.items.add_item and core.links.add_link (same for remove). Take a look at the Community OWM script to see some links.py usage. This PR is needed to get it working..

I was also getting exception when removing Items that hadn't gone through the JythonItemProvider, and I think I got that working now. 

There were some missing {} in log.py, preventing exceptions from being logged properly. This will hopefully get the exceptions from rules logged properly. In a previous commit, I had added a CloudNotification on exceptions, and I saw these coming in now with this change.