### PR TITLE
Version and OpenHAB compatibility check

### DIFF
--- a/Core/automation/jsr223/core/components/000_Version.py
+++ b/Core/automation/jsr223/core/components/000_Version.py
@@ -1,0 +1,11 @@
+import core
+from core.log import logging, LOG_PREFIX
+from org.openhab.core import OpenHAB
+
+log = logging.getLogger(LOG_PREFIX + ".core")
+
+def scriptLoaded(*args):
+    log.info("openhab2-jython version: {}".format(core.__version__))
+    if not core.openhab_support(OpenHAB.getVersion(), OpenHAB.buildString()):
+        log.warn("OpenHAB in version '{}' is not fully supported by openhab2-jython-{}".format(
+            OpenHAB.getVersion(), core.__version__))

--- a/Core/automation/lib/python/core/__init__.py
+++ b/Core/automation/lib/python/core/__init__.py
@@ -8,3 +8,24 @@ def _item_getattr(self, name):
     return self[name]
 
 type(items).__getattr__ = _item_getattr.__get__(items, type(items))
+
+__version__="1.0.0a"
+
+def openhab_support(version, build_number):
+    """Checks if given OpenHab version is compatible with this release
+
+    Arguments:
+        version {str} -- version of OpenHab (ex. 2.4.0, 2.4.0-M2)
+        build_number {str} -- build string reported by OpenHAB instance (ignored for now)
+
+    Returns:
+        True -- scripts are known to be working with this version of OH
+        False -- OH version is too old or not tested, issues might arise
+    """
+    from pkg_resources import parse_version
+
+    # Get rid of -SNAPSHOT or -MX suffix for 'epoch' comparison
+    ver_tuple = version.split("-", 1)
+    ver_epoch = parse_version(ver_tuple[0])
+
+    return ver_epoch >= parse_version("2.4.0")


### PR DESCRIPTION
Warns on startup if OpenHAB version is not supported by current release and prints nice version number on startup.

My take on some stuff from Issue #71. Version number probably should be generated from something, but as we don't have build nor test stages lets hard code it for now. 

Number 1.0.0a should conform to [PEP 440](https://www.python.org/dev/peps/pep-0440/) and indicates alpha release, probably should be bumped just on release date. 

If this will conflict with 2.7.1 changes, feel free to reject