### PR TITLE
[utils] The full item object is logged instead of the item's name

### DIFF
--- a/Core/automation/lib/python/core/utils.py
+++ b/Core/automation/lib/python/core/utils.py
@@ -112,10 +112,10 @@ def postUpdateCheckFirst(itemName, newValue, sendACommand=False, floatPrecision=
         if item.state != compareValue or (type(newValue) is float and floatPrecision is not None and round(item.state.floatValue(), floatPrecision) != newValue):
             if sendACommand:
                 sendCommand(item, newValue)
-                log.debug("New sendCommand value for [{}] is [{}]".format(itemName, newValue))
+                log.debug("New sendCommand value for [{}] is [{}]".format(item.name, newValue))
             else:
                 postUpdate(item, newValue)
-                log.debug("New postUpdate value for [{}] is [{}]".format(itemName, newValue))
+                log.debug("New postUpdate value for [{}] is [{}]".format(item.name, newValue))
             return True
         else:
             return False


### PR DESCRIPTION
See: https://github.com/OH-Jython-Scripters/openhab2-jython/issues/98