### PR TITLE
[date] Added calendar_days parameter

### DIFF
--- a/Core/automation/lib/python/core/date.py
+++ b/Core/automation/lib/python/core/date.py
@@ -59,10 +59,15 @@ def format_date(value, format_string="yyyy-MM-dd'T'HH:mm:ss.SSxx"):
     See java.time.format.DateTimeFormatter docs for format string tokens.'''
     return to_java_zoneddatetime(value).format(DateTimeFormatter.ofPattern(format_string))
 
-def days_between(value_from, value_to):
-    '''Returns number of whole days between value_from and value_to. 
+def days_between(value_from, value_to, calendar_days=False):
+    '''Returns number of whole days between value_from and value_to. Setting 
+    calendar_days=True will provide the number of calendar days, rather than 
+    24 hour intervals.
     Accepts any date type used by this module'''
-    return DAYS.between(to_java_zoneddatetime(value_from), to_java_zoneddatetime(value_to))
+    if calendar_days:
+        return DAYS.between(to_java_zoneddatetime(value_from).toLocalDate().atStartOfDay(), to_java_zoneddatetime(value_to).toLocalDate().atStartOfDay())
+    else:
+        return DAYS.between(to_java_zoneddatetime(value_from), to_java_zoneddatetime(value_to))
 
 def hours_between(value_from, value_to):
     '''Returns number of whole hours between value_from and value_to. 


### PR DESCRIPTION
The days_between function provides a result based on 24 hour intervals. I've added a calendar_days parameter so that you can specify if you'd like the result to return calendar days.

Resolves #107

Signed-off-by: Scott Rushworth <openhab@5iver.com>