### PR TITLE
Fix remove_item

### DIFF
--- a/Core/automation/lib/python/core/items.py
+++ b/Core/automation/lib/python/core/items.py
@@ -69,7 +69,7 @@ def remove_item(item_or_item_name):
             raise Exception("\"{}\" is not in the ItemRegistry".format(item.name))
         remove_all_links(item)
         JythonItemProvider.remove(item)
-        ManagedItemProvider.remove(item)
+        ManagedItemProvider.remove(item.name)
         log.debug("Item removed: [{}]".format(item))
     except:
         import traceback


### PR DESCRIPTION
ManagedItemProvider.remove() takes a string, not an item.

Signed-off-by: Scott Rushworth <openhab@5iver.com>